### PR TITLE
For webpack

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,3 @@
-var AWS = require('aws-sdk');
 var sanitize = require('./lib/sanitizer');
 var queries = require('./lib/queries');
 var suggestions = require('./lib/suggestions');
@@ -9,7 +8,8 @@ var operator = {
   'OR': 'or'
 };
 
-function init (endpoint) {
+function init (endpoint, AWS_instance) {
+  var AWS = AWS_instance || require('aws-sdk');
   cloudSearchDomain = new AWS.CloudSearchDomain({endpoint: endpoint});
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taggable-searcher",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Helper library to query the tag system",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Fixes https://github.com/numo-labs/taggable-searcher/issues/12 .
If you want to use this package in a webpack project you need to be able to pass through a 'pre-built' version of aws-sdk. 

http://andrewhfarmer.com/aws-sdk-with-webpack/