### PR TITLE
Taggy is now able to look for multiple return types

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Following is a list of options you can pass in the functions.
 | size | Integer | 1000 | The amount our results you want back. |
 | start | Integer | 0 | Specifies the offset of the first search hit you want to return. Note that the result set is zero-based; the first result is at index 0. |
 | operator | String | or | The query operator |
-| idPrefix | String | empty | E.g 'hotel', 'hotel:mhid', 'geo' |
+| idPrefix | Array | empty | E.g ['hotel', 'hotel:mhid', 'geo'] |
 
 ### Suggestions
 

--- a/lib/queries/name/index.js
+++ b/lib/queries/name/index.js
@@ -18,8 +18,7 @@ function computeQuery (names, options) {
     return util.format("(phrase field=displayname '%s')", name);
   }).join('');
 
-  var idPrefix = options.idPrefix ? "(prefix field=id '" + options.idPrefix + "')" : '';
-  return util.format('(%s %s %s)', options.operator, displayNames, idPrefix);
+  return util.format('(%s %s %s)', options.operator, displayNames, options.idPrefix);
 }
 
 module.exports = query;

--- a/lib/queries/tag/index.js
+++ b/lib/queries/tag/index.js
@@ -16,8 +16,7 @@ function query (tags, options, cloudSearchDomain, callback) {
 
 function computeQuery (tags, options) {
   var phrases = computePhrase(tags).join('');
-  var idPrefix = options.idPrefix ? "(prefix field=id '" + options.idPrefix + "')" : '';
-  return util.format('(%s %s %s)', options.operator, phrases, idPrefix);
+  return util.format('(%s %s %s)', options.operator, phrases, options.idPrefix);
 }
 
 function computePhrase (tags) {

--- a/lib/sanitizer.js
+++ b/lib/sanitizer.js
@@ -1,9 +1,11 @@
 var isInteger = require('lodash.isinteger');
+var isArray = require('lodash.isarray');
 
 var DEFAULT_QUERY_OPTIONS = {
   size: 1000,
   start: 0,
-  operator: 'or'
+  operator: 'or',
+  idPrefix: ''
 };
 
 var DEFAULT_SUGGESTION_OPTIONS = {
@@ -18,14 +20,24 @@ function queryOptions (options) {
     var sanitizedOptions = {
       size: isInteger(options.size) ? options.size : DEFAULT_QUERY_OPTIONS.size,
       start: isInteger(options.start) ? options.start : DEFAULT_QUERY_OPTIONS.start,
-      operator: operators.indexOf(options.operator) > -1 ? options.operator : DEFAULT_QUERY_OPTIONS.operator
+      operator: operators.indexOf(options.operator) > -1 ? options.operator : DEFAULT_QUERY_OPTIONS.operator,
+      idPrefix: options.idPrefix ? computeIdPrefixQuery(options.idPrefix) : DEFAULT_QUERY_OPTIONS.idPrefix
     };
 
-    if (options.idPrefix) sanitizedOptions.idPrefix = options.idPrefix;
+    if (options.idPrefix) sanitizedOptions.idPrefix = computeIdPrefixQuery(options.idPrefix);
     return sanitizedOptions;
   } else {
     return DEFAULT_QUERY_OPTIONS;
   }
+}
+
+function computeIdPrefixQuery (idPrefix) {
+  const idPrefixes = isArray(idPrefix) ? idPrefix : [idPrefix];
+  const prefixes = idPrefixes.map(function (prefix) {
+    return "(prefix field=id '" + prefix + "')";
+  });
+
+  return '(or ' + prefixes.join('') + ')';
 }
 
 function suggestionOptions (options) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taggable-searcher",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Helper library to query the tag system",
   "main": "index.js",
   "scripts": {

--- a/test/query_multiple.integration.js
+++ b/test/query_multiple.integration.js
@@ -11,7 +11,7 @@ describe('Integration test for multiple queries', function () {
       assert.equal(data.hits.found, 3);
       assert.equal(data.hits.hit.length, 1);
       assert.equal(data.hits.start, 0);
-      index.searchByTags(data.hits.hit[0].id, {size: 10, start: 3, idPrefix: 'hotel:NE'}, function (err, data) {
+      index.searchByTags(data.hits.hit[0].id, {size: 10, start: 3, idPrefix: ['hotel:NE', 'hotel:mhid']}, function (err, data) {
         if (err) return done(err);
         assert.equal(data.hits.hit.length, 10);
         assert.equal(data.hits.start, 3);
@@ -19,4 +19,4 @@ describe('Integration test for multiple queries', function () {
       });
     });
   });
-});
+});// (or (phrase field=geotags 'geo:geonames.2510769') (or (prefix field=id 'hotel:NE')(prefix field=id 'hotel:mhid')))


### PR DESCRIPTION
This change is backwards compatible.
If you use a string for idPrefix it will be converted to an array in the background.