### PR TITLE
Fixed wrong interpretation of hotel search by tile

### DIFF
--- a/lib/search/hotel.js
+++ b/lib/search/hotel.js
@@ -53,7 +53,7 @@ function getTileFilters (tiles, callback) {
   if (tiles && tiles.length) {
     var params = {
       linkType: ':FILTERS',
-      maxDept: 5
+      maxDepth: 5
     };
 
     var filters = {
@@ -134,14 +134,21 @@ function query (queries, hotelsToAdd, callback) {
     err = err || null; // if no error return null
     // Intersect the search results together
     var intersected = intersectResults(result);
-    if (hotelsToAdd.length) intersected.data.push(filterUniqueHotels(hotelsToAdd, intersected.hotelIds));
+
+    // If we have extra hotels to add, add them here.
+    if (hotelsToAdd.length) {
+      filterUniqueHotels(hotelsToAdd, intersected.hotelIds).forEach(function (hotel) {
+        intersected.data.push({hotel: hotel});
+      });
+    }
     return callback(err, {queries: intersected.queries, data: intersected.data});
   });
 }
 
 function filterUniqueHotels (hotels, hotelIdsToFilter) {
   return hotels.map(function (hotel) {
-    if (~hotelIdsToFilter.indexOf(hotel.properties.id)) return hotel;
+    // Only add it when it is not in the list yet.
+    if (hotelIdsToFilter.indexOf(hotel.properties.id) === -1) return hotel;
   }).filter(function (hotel) { if (hotel) return hotel; });
 }
 

--- a/lib/search/hotel.js
+++ b/lib/search/hotel.js
@@ -160,7 +160,7 @@ function intersectResults (results) {
     var smallestList = results[0].length > results[1].length ? 0 : 1;
     var hotelIds = mapToIdsToArray(results[smallestList].data);
     var data = results[smallestList === 0 ? 1 : 0].data.map(function (node) {
-      if (~hotelIds.indexOf(node.hotel.properties.id)) return node;
+      if (hotelIds.indexOf(node.hotel.properties.id) > -1) return node;
     }).filter(function (node) { if (node) return node; });
     return {queries: queries, data: data, hotelIds: hotelIds};
   }

--- a/lib/search/hotel.js
+++ b/lib/search/hotel.js
@@ -53,7 +53,7 @@ function getTileFilters (tiles, callback) {
   if (tiles && tiles.length) {
     var params = {
       linkType: ':FILTERS',
-      maxDept: 1
+      maxDept: 5
     };
 
     var filters = {
@@ -70,7 +70,7 @@ function getTileFilters (tiles, callback) {
         var id = tag.node.properties.id;
         if (type === 'amenity') filters.amenities.push(id);
         else if (type === 'marketing') filters.marketing.push(id);
-        else if (type === 'hotel') filters.hotels.push(id);
+        else if (type === 'hotel') filters.hotels.push(tag.node);
         else if (type === 'geo') filters.geography.push(id);
       });
       return callback(null, filters);
@@ -127,47 +127,41 @@ function computeMarketingQuery (fastQuery, marketing) {
 /**
  * Executes each query group. (Query groups are based on geo.)
  */
-function query (queries, hotelsToIntersect, callback) {
+function query (queries, hotelsToAdd, callback) {
   async.parallel(queries.map(function (query) {
     return computeQueryFunctions(query, database);
   }), function (err, result) {
     err = err || null; // if no error return null
+    // Intersect the search results together
+    var intersected = intersectResults(result);
+    if (hotelsToAdd.length) intersected.data.push(filterUniqueHotels(hotelsToAdd, intersected.hotelIds));
+    return callback(err, {queries: intersected.queries, data: intersected.data});
+  });
+}
 
-    var returnObject = {
-      queries: [],
-      data: []
-    };
+function filterUniqueHotels (hotels, hotelIdsToFilter) {
+  return hotels.map(function (hotel) {
+    if (~hotelIdsToFilter.indexOf(hotel.properties.id)) return hotel;
+  }).filter(function (hotel) { if (hotel) return hotel; });
+}
 
-    // If there is only one result set we can immediately return.
-    if (!hotelsToIntersect.length && result.length === 1) {
-      // Add queries
-      returnObject.queries.push(result[0].query);
+function intersectResults (results) {
+  if (!results.length) return {queries: [], data: [], hotelIds: []};
+  else if (results.length === 1) return {queries: results[0].query, data: results[0].data, hotelIds: mapToIdsToArray(results[0].data)};
+  else {
+    var queries = [results[0].query, results[1].query];
+    var smallestList = results[0].length > results[1].length ? 0 : 1;
+    var hotelIds = mapToIdsToArray(results[smallestList].data);
+    var data = results[smallestList === 0 ? 1 : 0].data.map(function (node) {
+      if (~hotelIds.indexOf(node.hotel.properties.id)) return node;
+    }).filter(function (node) { if (node) return node; });
+    return {queries: queries, data: data, hotelIds: hotelIds};
+  }
+}
 
-      // Add nodes
-      returnObject.data = result[0].data;
-    } else if (hotelsToIntersect.length) {
-      result.forEach(function (r) {
-        returnObject.queries.push(r.query);
-        r.data.forEach(function (node) {
-          if (~hotelsToIntersect.indexOf(node.hotel.properties.id)) {
-            returnObject.data.push(node);
-          }
-        });
-      });
-    } else if (!hotelsToIntersect.length && result.length > 0) {
-      // We know we have max 2 results (general and marketing);
-      returnObject.queries.push([result[0].query, result[1].query]);
-      // We take the smallest list to be the intersection candidate so that array.contains will be faster.
-      var intersectionIndex = result[0].length > result[1].length ? 0 : 1;
-      var intersections = result[intersectionIndex].data.map(function (node) {
-        return node.hotel.properties.id;
-      });
-      returnObject.data = result[intersectionIndex === 0 ? 1 : 0].data.map(function (node) {
-        if (~intersections.indexOf(node.hotel.properties.id)) return node;
-      }).filter(function (node) { if (node) return node; });
-    }
-
-    return callback(err, returnObject);
+function mapToIdsToArray (data) {
+  return data.map(function (node) {
+    return node.hotel.properties.id;
   });
 }
 

--- a/lib/search/node.js
+++ b/lib/search/node.js
@@ -23,9 +23,9 @@ function outgoing (params, callback) {
   var limit = params.limit ? 'LIMIT ' + params.limit : '';
   var label = params.label || '';
   var linkType = params.linkType || '';
-  var maxDept = params.maxDept ? '*..' + params.maxDept : '';
+  var maxDepth = params.maxDepth ? '*..' + params.maxDepth : '';
   var q = nodeId.map(function (id) {
-    return util.format('MATCH (n {id:"%s"})-[relationship%s%s]->(node%s) RETURN relationship,node %s', id, linkType, maxDept, label, limit);
+    return util.format('MATCH (n {id:"%s"})-[relationship%s%s]->(node%s) RETURN relationship,node %s', id, linkType, maxDepth, label, limit);
   }).join(' UNION ');
   query(q, callback);
 }
@@ -34,9 +34,9 @@ function incoming (params, callback) {
   var limit = params.limit ? 'LIMIT ' + params.limit : '';
   var label = params.label || '';
   var linkType = params.linkType || '';
-  var maxDept = params.maxDept ? '*..' + params.maxDept : '';
+  var maxDepth = params.maxDepth ? '*..' + params.maxDepth : '';
   var q = nodeId.map(function (id) {
-    return util.format('MATCH (n {id:"%s"})<-[relationship%s%s]-(node%s) RETURN relationship,node %s', id, linkType, maxDept, label, limit);
+    return util.format('MATCH (n {id:"%s"})<-[relationship%s%s]-(node%s) RETURN relationship,node %s', id, linkType, maxDepth, label, limit);
   }).join(' UNION ');
   query(q, callback);
 }
@@ -45,9 +45,9 @@ function links (params, callback) {
   var limit = params.limit ? 'LIMIT ' + params.limit : '';
   var label = params.label || '';
   var linkType = params.linkType || '';
-  var maxDept = params.maxDept ? '*..' + params.maxDept : '';
+  var maxDepth = params.maxDepth ? '*..' + params.maxDepth : '';
   var q = nodeId.map(function (id) {
-    return util.format('MATCH (n {id:"%s"})-[relationship%s%s]-(node%s) RETURN relationship,node %s', nodeId, linkType, maxDept, label, limit);
+    return util.format('MATCH (n {id:"%s"})-[relationship%s%s]-(node%s) RETURN relationship,node %s', nodeId, linkType, maxDepth, label, limit);
   }).join(' UNION ');
   query(q, callback);
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "taggable-searcher",
-  "version": "5.1.3",
+  "version": "5.1.4",
   "description": "Helper library to query the tag system",
   "main": "index.js",
   "scripts": {

--- a/test/invoke.search.hotel.js
+++ b/test/invoke.search.hotel.js
@@ -12,6 +12,7 @@ describe('Integration: search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -23,6 +24,7 @@ describe('Integration: search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -35,6 +37,7 @@ describe('Integration: search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -50,6 +53,7 @@ describe('Integration: search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -65,7 +69,7 @@ describe('Integration: search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
-      console.log('result', result);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -82,6 +86,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -94,6 +99,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -107,6 +113,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -123,6 +130,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -139,7 +147,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) done(err);
       assert(result.data.length > 0);
-      console.log('result', result);
+      console.log('results:', result.data.length);
       done();
     });
   });
@@ -153,6 +161,7 @@ describe('Integration (fastQuery): search.hotel', function () {
     index.search.hotel(params, function (err, result) {
       if (err) return done(err);
       assert(result.data.length > 0);
+      console.log('results:', result.data.length);
       done();
     });
   });

--- a/test/invoke.search.node.js
+++ b/test/invoke.search.node.js
@@ -5,7 +5,7 @@ var index = require('../index');
 describe('Integration: search.node', function () {
   it('should find the incoming nodes for a tiles', function (done) {
     var params = {
-      maxDept: 1,
+      maxDepth: 1,
       limit: 2
     };
 


### PR DESCRIPTION
Previously when searching for hotels based on a tile id we did an intersection with the hotels linked to the tile and the hotels found linked by other nodes filtered by this tile.

This should never have been an intersect but a union.

So this PR will add the hotels directly linked to the tile to the results of the other hotels found.