### PR TITLE
Show deprecation message if using implicit neo4j config

### DIFF
--- a/lib/search/hotel.js
+++ b/lib/search/hotel.js
@@ -3,10 +3,13 @@ var neo4j = require('neo4j');
 var async = require('async');
 var uniq = require('lodash.uniq');
 var search = require('./index');
+var deprecate = require('depd')('taggable-searcher:search:hotel');
 
 var database;
 
 function init (endpoint) {
+  /* istanbul ignore next */
+  if (!endpoint) { deprecate('Implicit configuration of NEO4J_ENDPOINT via environment variables is deprecated. You should pass the endpoint as an argument to init()'); }
   if (!database) database = new neo4j.GraphDatabase(endpoint || process.env.NEO4J_ENDPOINT);
 }
 

--- a/lib/search/node.js
+++ b/lib/search/node.js
@@ -1,10 +1,13 @@
 var util = require('util');
 var neo4j = require('neo4j');
+var deprecate = require('depd')('taggable-searcher:search:node');
 
 var database;
 var nodeId;
 
 function init (endpoint) {
+  /* istanbul ignore next */
+  if (!endpoint) { deprecate('Implicit configuration of NEO4J_ENDPOINT via environment variables is deprecated. You should pass the endpoint as an argument to init()'); }
   if (!database) database = new neo4j.GraphDatabase(endpoint || process.env.NEO4J_ENDPOINT);
 }
 

--- a/lib/search/tile.js
+++ b/lib/search/tile.js
@@ -1,8 +1,12 @@
 var isArray = require('lodash.isarray');
 var neo4j = require('neo4j');
+var deprecate = require('depd')('taggable-searcher:search:tile');
+
 var database;
 
 function init (endpoint) {
+  /* istanbul ignore next */
+  if (!endpoint) { deprecate('Implicit configuration of NEO4J_ENDPOINT via environment variables is deprecated. You should pass the endpoint as an argument to init()'); }
   if (!database) database = new neo4j.GraphDatabase(endpoint || process.env.NEO4J_ENDPOINT);
 }
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "homepage": "https://github.com/numo-labs/taggable-searcher",
   "dependencies": {
     "async": "^1.5.2",
+    "depd": "^1.1.0",
     "elasticsearch": "^11.0.1",
     "http-aws-es": "^1.1.3",
     "lodash.flatten": "^4.2.0",


### PR DESCRIPTION
We want to avoid implicitly configuring dependencies with environment variables, in favour of explicitly passing them to init functions from the parent module. 

Add a deprecation message to flag to developers when configuration is being implicitly applied.