### PR TITLE
Exclude inactive tags from `suggest` query

### DIFF
--- a/lib/suggest/index.js
+++ b/lib/suggest/index.js
@@ -102,7 +102,8 @@ function shouldInclude (text, items, should) {
 
 function buildQuery (options) {
   return {
-    must: computeMustQuery(options.text, options.context)
+    must: computeMustQuery(options.text, options.context),
+    must_not: { term: { active: false } }
   };
 }
 


### PR DESCRIPTION
Adds a filter to the elasticsearch query that explicitly excludes inactive tags. Note that the filter cannot require `active: true` because most of the json files in s3 do not have any active property at all. It is only tags which have recently been edited that will have the property present.