### PR TITLE
Pass an option to filter out inactive tags

### DIFF
--- a/lib/suggest/index.js
+++ b/lib/suggest/index.js
@@ -101,10 +101,13 @@ function shouldInclude (text, items, should) {
 }
 
 function buildQuery (options) {
-  return {
-    must: computeMustQuery(options.text, options.context),
-    must_not: { term: { active: false } }
+  const query = {
+    must: computeMustQuery(options.text, options.context)
   };
+  if (options.activeOnly) {
+    query.must_not = { term: { active: false } };
+  }
+  return query;
 }
 
 function computeMustQuery (text, context) {

--- a/lib/suggest/optionsHandler.js
+++ b/lib/suggest/optionsHandler.js
@@ -7,7 +7,8 @@ function cloudSearch (options) {
     text: options.text,
     size: isInteger(options.size) ? options.size : 10,
     start: isInteger(options.start) ? options.start : 0,
-    operator: ['or', 'and'].indexOf(options.operator) > -1 ? options.operator : 'and'
+    operator: ['or', 'and'].indexOf(options.operator) > -1 ? options.operator : 'and',
+    activeOnly: options.activeOnly || false
   };
   if (options.context) o.context = options.context;
 

--- a/test/optionsHandler.test.js
+++ b/test/optionsHandler.test.js
@@ -19,7 +19,8 @@ describe('optionsHandler', function () {
       start: 15,
       size: 125,
       operator: 'or',
-      include: ['hotel']
+      include: ['hotel'],
+      activeOnly: false
     };
 
     var result = optionsHandler(options);
@@ -36,7 +37,8 @@ describe('optionsHandler', function () {
       text: 'Spa',
       operator: 'and',
       size: 10,
-      start: 0
+      start: 0,
+      activeOnly: false
     };
 
     var result = optionsHandler(options);
@@ -53,7 +55,8 @@ describe('optionsHandler', function () {
       text: 'Spa',
       operator: 'and',
       size: 10,
-      start: 0
+      start: 0,
+      activeOnly: false
     };
 
     var result = optionsHandler(options);
@@ -70,7 +73,8 @@ describe('optionsHandler', function () {
       text: 'Spa',
       operator: 'and',
       size: 10,
-      start: 0
+      start: 0,
+      activeOnly: false
     };
 
     var result = optionsHandler(options);
@@ -88,7 +92,8 @@ describe('optionsHandler', function () {
       operator: 'and',
       size: 10,
       start: 0,
-      include: ['single item']
+      include: ['single item'],
+      activeOnly: false
     };
 
     var result = optionsHandler(options);
@@ -106,7 +111,8 @@ describe('optionsHandler', function () {
       operator: 'and',
       size: 10,
       start: 0,
-      exclude: ['single item']
+      exclude: ['single item'],
+      activeOnly: false
     };
 
     var result = optionsHandler(options);


### PR DESCRIPTION
This means that taggable-ui can still get all tags, including inactive tags, but the autosuggest on isearch-ui can filter down to only active.