### PR TITLE
Perform include and exclude filtering at the elasticsearch query level

### DIFF
--- a/lib/suggest/index.js
+++ b/lib/suggest/index.js
@@ -1,4 +1,3 @@
-var isArray = require('lodash.isarray');
 var AWS = require('aws-sdk');
 var ElasticSearch = require('elasticsearch');
 var optionsHandler = require('./optionsHandler');
@@ -54,60 +53,54 @@ function suggest (o, callback) {
   });
 }
 
+function buildQuery (options) {
+  const query = {
+    must: computeMustQuery(options.text, options.context)
+  };
+  query.must_not = [];
+  if (options.activeOnly) {
+    query.must_not.push({ term: { active: false } });
+  }
+  if (options.exclude && options.exclude.length) {
+    options.exclude.forEach((type) => {
+      query.must_not.push({ prefix: { tagid: type } });
+    });
+  } else if (options.include && options.include.length) {
+    const or = [];
+    options.include.forEach((type) => {
+      or.push({ prefix: { tagid: type } });
+    });
+    query.must.push({ bool: { should: or } });
+  }
+  return query;
+}
+
 function formatResult (data, options, callback) {
   data.hits.hits = uniq(data.hits.hits, hit => hit._source.tagid);
-  var filter = filterData(options);
   var result = {
     status: {
       timesms: data.took
     },
     hits: {
+      found: data.hits.hits.length,
       start: options.start || 0,
-      hit: data.hits.hits.map(function (hit) {
-        if (shouldInclude(hit._source.tagid, filter.list, filter.shouldInclude)) {
-          return {
-            id: hit._id,
-            score: hit._score,
-            fields: {
-              name: hit._source.name,
-              tagid: hit._source.tagid,
-              label: hit._source.label,
-              context: hit._source.context,
-              active: hit._source.active,
-              boost: hit._source.boost
-            }
-          };
-        }
-      }).filter(function (hit) {
-        if (hit) return hit;
+      hit: data.hits.hits.map((hit) => {
+        return {
+          id: hit._id,
+          score: hit._score,
+          fields: {
+            name: hit._source.name,
+            tagid: hit._source.tagid,
+            label: hit._source.label,
+            context: hit._source.context,
+            active: hit._source.active,
+            boost: hit._source.boost
+          }
+        };
       })
     }
   };
-  result.hits.found = result.hits.hit.length;
-  callback(null, { filter: filter, data: result });
-}
-
-function filterData (options) {
-  const include = isArray(options.include);
-  return {
-    shouldInclude: include,
-    list: options.include || options.exclude || []
-  };
-}
-
-function shouldInclude (text, items, should) {
-  if (items.length === 0) return true;
-  return (items.indexOf(text.substring(0, text.indexOf(':'))) > -1) === should;
-}
-
-function buildQuery (options) {
-  const query = {
-    must: computeMustQuery(options.text, options.context)
-  };
-  if (options.activeOnly) {
-    query.must_not = { term: { active: false } };
-  }
-  return query;
+  callback(null, { data: result });
 }
 
 function computeMustQuery (text, context) {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "aws-sdk": "^2.3.8",
     "env2": "^2.0.7",
     "istanbul": "^0.4.3",
-    "lodash.every": "^4.4.0",
     "mocha": "^2.4.5",
     "semistandard": "^7.0.5",
     "simple-mock": "^0.7.0",


### PR DESCRIPTION
This means that any pagination parameters will be respected irrespective of filters that were subsequently applied. By not having to iterate over the full result set in memory we might see an additional performance improvement also.

Fixes numo-labs/isearch-ui#389