### PR TITLE
Return total number of suggest results before pagination

### DIFF
--- a/lib/suggest/index.js
+++ b/lib/suggest/index.js
@@ -82,7 +82,7 @@ function formatResult (data, options, callback) {
       timesms: data.took
     },
     hits: {
-      found: data.hits.hits.length,
+      found: data.hits.total,
       start: options.start || 0,
       hit: data.hits.hits.map((hit) => {
         return {

--- a/test/store/index.js
+++ b/test/store/index.js
@@ -3,11 +3,12 @@ const AWS = require('aws-sdk');
 const assert = require('assert');
 const store = require('../../').store;
 
+const S3 = (new AWS.S3()).constructor.prototype;
 describe('store', () => {
   const mockResult = { Body: { toString: simple.mock().returnWith('test-string') } };
   beforeEach(() => {
     mockResult.Body.toString.reset();
-    simple.mock(AWS.S3.prototype, 'getObject').callbackWith(null, mockResult);
+    simple.mock(S3, 'getObject').callbackWith(null, mockResult);
     store.init('numo-taggy', 'ci');
   });
   afterEach(() => {
@@ -15,13 +16,13 @@ describe('store', () => {
   });
   it('calls through to S3.getObject', (done) => {
     store.get('geo:geonames.10062607', () => {
-      assert.equal(AWS.S3.prototype.getObject.callCount, 1);
+      assert.equal(S3.getObject.callCount, 1);
       done();
     });
   });
   it('loads from "numo-taggy" bucket', (done) => {
     store.get('geo:geonames.10062607', () => {
-      const params = AWS.S3.prototype.getObject.lastCall.args[0];
+      const params = S3.getObject.lastCall.args[0];
       assert.equal(params.Bucket, 'numo-taggy');
       done();
     });
@@ -35,8 +36,8 @@ describe('store', () => {
     });
   });
   it('calls callback with error if S3.getObject fails', (done) => {
-    AWS.S3.prototype.getObject.actions = [];
-    AWS.S3.prototype.getObject.callbackWith(new Error('test error'));
+    S3.getObject.actions = [];
+    S3.getObject.callbackWith(new Error('test error'));
     store.get('geo:geonames.10062607', (err, result) => {
       assert(err);
       assert.equal(err.message, 'test error');
@@ -46,21 +47,21 @@ describe('store', () => {
   describe('object key generation', () => {
     it('geo:geonames.10062607', (done) => {
       store.get('geo:geonames.10062607', () => {
-        const params = AWS.S3.prototype.getObject.lastCall.args[0];
+        const params = S3.getObject.lastCall.args[0];
         assert.equal(params.Key, 'ci/geo/geonames/geo:geonames.10062607.json');
         done();
       });
     });
     it('marketing:term.spa', (done) => {
       store.get('marketing:term.spa', () => {
-        const params = AWS.S3.prototype.getObject.lastCall.args[0];
+        const params = S3.getObject.lastCall.args[0];
         assert.equal(params.Key, 'ci/marketing/term/marketing:term.spa.json');
         done();
       });
     });
     it('amenity:ne.wifi', (done) => {
       store.get('amenity:ne.wifi', () => {
-        const params = AWS.S3.prototype.getObject.lastCall.args[0];
+        const params = S3.getObject.lastCall.args[0];
         assert.equal(params.Key, 'ci/amenity/ne/amenity:ne.wifi.json');
         done();
       });
@@ -70,7 +71,7 @@ describe('store', () => {
     it('sets the environment if passed as a parameter', (done) => {
       store.init(null, 'prod');
       store.get('geo:geonames.10062607', () => {
-        const params = AWS.S3.prototype.getObject.lastCall.args[0];
+        const params = S3.getObject.lastCall.args[0];
         assert.equal(params.Key, 'prod/geo/geonames/geo:geonames.10062607.json');
         done();
       });
@@ -78,7 +79,7 @@ describe('store', () => {
     it('sets the bucket if passed as a parameter', (done) => {
       store.init('test-bucket');
       store.get('geo:geonames.10062607', () => {
-        const params = AWS.S3.prototype.getObject.lastCall.args[0];
+        const params = S3.getObject.lastCall.args[0];
         assert.equal(params.Bucket, 'test-bucket');
         done();
       });

--- a/test/suggest/fixtures/paginated-result.json
+++ b/test/suggest/fixtures/paginated-result.json
@@ -1,0 +1,138 @@
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "failed": 0
+  },
+  "hits": {
+    "total": 80,
+    "max_score": 6.0852137,
+    "hits": [
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:geo:geonames.2510769",
+        "_score": 6.0852137,
+        "_source": {
+          "name": "Spanien",
+          "label": "Spanien",
+          "tagid": "geo:geonames.2510769",
+          "context": "dk:da",
+          "active": true
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:geo:geonames.6946451",
+        "_score": 3.0145535,
+        "_source": {
+          "name": "Spanisches Dorf \"Pueblo Espanol\"",
+          "label": "Spanisches Dorf \"Pueblo Espanol\"",
+          "tagid": "geo:geonames.6946451",
+          "context": "dk:da",
+          "active": true
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:geo:geonames.6947342",
+        "_score": 2.3870134,
+        "_source": {
+          "name": "Spanisches Dorf \"Pueblo Espanol\"",
+          "label": "Spanisches Dorf \"Pueblo Espanol\"",
+          "tagid": "geo:geonames.6947342",
+          "context": "dk:da",
+          "active": true
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:marketing:term.spa",
+        "_score": 2.0091918,
+        "_source": {
+          "name": "Spa",
+          "label": "Spa & Relax",
+          "tagid": "marketing:term.spa",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.csnasp6",
+        "_score": 1.8652625,
+        "_source": {
+          "name": "Hotel Spa Villalba, Vilaflor",
+          "label": "Hotel Spa Villalba, Vilaflor",
+          "tagid": "hotel:mhid.csnasp6",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.sww35ky",
+        "_score": 1.8583529,
+        "_source": {
+          "name": "Kirini Suites & Spa, Oia",
+          "label": "Kirini Suites & Spa, Oia",
+          "tagid": "hotel:mhid.sww35ky",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.u7ptuee",
+        "_score": 1.8145988,
+        "_source": {
+          "name": "Elysium Resort & Spa, Faliraki",
+          "label": "Elysium Resort & Spa, Faliraki",
+          "tagid": "hotel:mhid.u7ptuee",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.8auu1n7",
+        "_score": 1.7179248,
+        "_source": {
+          "name": "Royalton Hicacos Resort & Spa, Varadero",
+          "label": "Royalton Hicacos Resort & Spa, Varadero",
+          "tagid": "hotel:mhid.8auu1n7",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.dtqqq2j",
+        "_score": 1.7179248,
+        "_source": {
+          "name": "Royal Island Resort & Spa, Maldiverne",
+          "label": "Royal Island Resort & Spa, Maldiverne",
+          "tagid": "hotel:mhid.dtqqq2j",
+          "context": "dk:da"
+        }
+      },
+      {
+        "_index": "taggy",
+        "_type": "taggy",
+        "_id": "dk:da:0:hotel:mhid.zxLhfat",
+        "_score": 1.7179248,
+        "_source": {
+          "name": "Royal Atlas Hotel & Spa, Agadir",
+          "label": "Royal Atlas Hotel & Spa, Agadir",
+          "tagid": "hotel:mhid.zxLhfat",
+          "context": "dk:da"
+        }
+      }
+    ]
+  }
+}

--- a/test/suggest/index.js
+++ b/test/suggest/index.js
@@ -83,6 +83,17 @@ describe('suggest', () => {
         });
       });
     });
+    describe('count', () => {
+      it('includes the total number of results, before pagination', (done) => {
+        mockClient.search.actions = [];
+        mockClient.search.callbackWith(null, require('./fixtures/paginated-result.json'));
+        suggest({ text: 'spa', size: 10 }, (err, result) => {
+          assert(!err);
+          assert.equal(result.data.hits.found, 80);
+          done();
+        });
+      });
+    });
   });
 
   describe('error handling', () => {


### PR DESCRIPTION
The `found` property is used by taggable-ui to render pagination controls and so should be the total number of matching records reported by the elasticsearch query rather than simply the number of results in the current result set.
